### PR TITLE
Support for continue/start conversation

### DIFF
--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -1019,17 +1019,29 @@ voice_assistant:
   on_tts_start:
     - lambda: id(voice_assistant_phase) = ${voice_assist_replying_phase_id};
     - script.execute: control_leds
+    # Stop wake word detection to save memory for assist_satellite.start_conversation
+    - if:
+        condition:
+          micro_wake_word.is_running:
+        then:
+          - micro_wake_word.stop:
   # When the voice assistant ends ...
   on_end:
     - wait_until:
         not:
           voice_assistant.is_running:
+    # Start wake word detection only if not already running
+    - if:
+        condition:
+          not:
+            micro_wake_word.is_running:
+        then:
+          - micro_wake_word.start:
     # Stop ducking audio.
     - mixer_speaker.apply_ducking:
         id: media_mixing_input
         decibel_reduction: 0
         duration: 1.0s
-    - micro_wake_word.start:
     # If the end happened because of an error, let the error phase on for a second
     - if:
         condition:

--- a/home-assistant-voice.yaml
+++ b/home-assistant-voice.yaml
@@ -926,6 +926,15 @@ media_player:
       - id: wake_word_triggered_sound
         file: https://github.com/esphome/home-assistant-voice-pe/raw/dev/sounds/wake_word_triggered.flac
 
+external_components:
+  - source:
+      type: git
+      url: https://github.com/esphome/home-assistant-voice-pe
+      ref: dev
+    components:
+      - voice_assistant
+    refresh: 0s
+
 micro_wake_word:
   id: mww
   models:
@@ -1012,7 +1021,6 @@ voice_assistant:
     - script.execute: control_leds
   # When the voice assistant ends ...
   on_end:
-    - micro_wake_word.start:
     - wait_until:
         not:
           voice_assistant.is_running:
@@ -1021,6 +1029,7 @@ voice_assistant:
         id: media_mixing_input
         decibel_reduction: 0
         duration: 1.0s
+    - micro_wake_word.start:
     # If the end happened because of an error, let the error phase on for a second
     - if:
         condition:


### PR DESCRIPTION
Hi

I was waiting for this feature a lot. Unfortunately it's still not available in esphome 2025.3.3 and 2025.4.0-dev.
So I decided to use voice_assistant component from [home-assistant-voice-pe](https://github.com/esphome/home-assistant-voice-pe/tree/dev).
I also had to move "micro_wake_word.start" position.

voice_assistant version can be hard coded using:
```yaml
external_components:
  - source: github://esphome/home-assistant-voice-pe@25.3.4
    components: [ voice_assistant ]
```

Below you can see how it works:
[![Video Title](http://img.youtube.com/vi/uaCn4SHi0-M/0.jpg)](http://www.youtube.com/watch?v=uaCn4SHi0-M)